### PR TITLE
Add bulk/streaming api

### DIFF
--- a/cmd/gobl/serve.go
+++ b/cmd/gobl/serve.go
@@ -154,15 +154,10 @@ func (s *serveOpts) verify(c echo.Context) error {
 	return c.JSON(http.StatusOK, &internal.VerifyResponse{OK: true})
 }
 
-type keygenResponse struct {
-	Private *dsig.PrivateKey `json:"private"`
-	Public  *dsig.PublicKey  `json:"public"`
-}
-
 func (s *serveOpts) keygen(c echo.Context) error {
 	key := dsig.NewES256Key()
 
-	return c.JSON(http.StatusOK, keygenResponse{
+	return c.JSON(http.StatusOK, internal.KeygenResponse{
 		Private: key,
 		Public:  key.Public(),
 	})

--- a/cmd/gobl/serve.go
+++ b/cmd/gobl/serve.go
@@ -147,28 +147,19 @@ func prepareBuildOpts(c echo.Context) (*internal.BuildOptions, error) {
 	return opts, nil
 }
 
-type verifyRequest struct {
-	Data      json.RawMessage `json:"data"`
-	PublicKey *dsig.PublicKey `json:"publickey"`
-}
-
-type verifyResponse struct {
-	OK bool `json:"ok"`
-}
-
 func (s *serveOpts) verify(c echo.Context) error {
 	ct, _, _ := mime.ParseMediaType(c.Request().Header.Get("Content-Type"))
 	if ct != "application/json" {
 		return echo.NewHTTPError(http.StatusUnsupportedMediaType)
 	}
-	req := new(verifyRequest)
+	req := new(internal.VerifyRequest)
 	if err := c.Bind(req); err != nil {
 		return err
 	}
 	if err := internal.Verify(c.Request().Context(), bytes.NewReader(req.Data), req.PublicKey); err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, &verifyResponse{OK: true})
+	return c.JSON(http.StatusOK, &internal.VerifyResponse{OK: true})
 }
 
 type keygenResponse struct {

--- a/cmd/gobl/serve.go
+++ b/cmd/gobl/serve.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"mime"
 	"net/http"
@@ -87,13 +86,6 @@ func (s *serveOpts) version(c echo.Context) error {
 	})
 }
 
-type buildRequest struct {
-	Template   json.RawMessage  `json:"template"`
-	Data       json.RawMessage  `json:"data"`
-	PrivateKey *dsig.PrivateKey `json:"privatekey"`
-	DocType    string           `json:"type"`
-}
-
 func (s *serveOpts) build(c echo.Context) error {
 	opts, err := prepareBuildOpts(c)
 	if err != nil {
@@ -129,7 +121,7 @@ func prepareBuildOpts(c echo.Context) (*internal.BuildOptions, error) {
 	if ct != "application/json" {
 		return nil, echo.NewHTTPError(http.StatusUnsupportedMediaType)
 	}
-	req := new(buildRequest)
+	req := new(internal.BuildRequest)
 	if err := c.Bind(req); err != nil {
 		return nil, err
 	}

--- a/cmd/gobl/verify.go
+++ b/cmd/gobl/verify.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/invopop/gobl.cli/internal"
 	"github.com/invopop/gobl/dsig"
-	"github.com/spf13/cobra"
 )
 
 type verifyOpts struct {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/go-cmp v0.5.6
 	github.com/imdario/mergo v0.3.12
 	github.com/invopop/gobl v0.18.0
 	github.com/labstack/echo/v4 v4.6.3

--- a/internal/bulk.go
+++ b/internal/bulk.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"sync/atomic"
 
@@ -96,6 +97,8 @@ func processRequest(ctx context.Context, req BulkRequest, seq int64, err error) 
 			return res
 		}
 		res.Payload, _ = json.Marshal(env)
+	default:
+		res.Error = fmt.Sprintf("Unrecognized action '%s'", req.Action)
 	}
 	return res
 }

--- a/internal/bulk.go
+++ b/internal/bulk.go
@@ -1,0 +1,61 @@
+package internal
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// BulkRequest represents a single request in the stream of bulk requests.
+type BulkRequest struct {
+	// Action is the action to perform on the payload.
+	Action string `json:"action"`
+	// ReqID is an opaque request ID, which is returned with the associated
+	// response.
+	ReqID string `json:"req_id"`
+	// Payload is the payload upon which to perform the action.
+	Payload json.RawMessage `json:"payload"`
+}
+
+// BulkResponse represents a singel response in the stream of bulk responses.
+type BulkResponse struct {
+	// ReqID is an exact copy of the value provided in the request, if any.
+	ReqID string `json:"req_id,omitempty"`
+	// SeqID is the sequence ID of the request this response correspond to,
+	// starting at 0.
+	SeqID int64 `json:"seq_id"`
+	// Payload is the response payload.
+	Payload json.RawMessage `json:"payload"`
+	// Error represents an error processing a request item.
+	Error string `json:"error"`
+	// IsFinal will be true once the end of the request input stream has been
+	// reached, or an unrecoverable error has occurred.
+	IsFinal bool `json:"is_final"`
+}
+
+// Bulk processes a stream of bulk requests.
+func Bulk(in io.Reader) <-chan *BulkResponse {
+	dec := json.NewDecoder(in)
+	var seq int64
+	resCh := make(chan *BulkResponse, 1)
+	go func() {
+		defer close(resCh)
+		for {
+			var req BulkRequest
+			err := dec.Decode(&req)
+			res := &BulkResponse{
+				ReqID:   req.ReqID,
+				SeqID:   seq,
+				IsFinal: err != nil,
+			}
+			if err != nil && err != io.EOF {
+				res.Error = err.Error()
+			}
+			resCh <- res
+			if err != nil {
+				return
+			}
+			seq++
+		}
+	}()
+	return resCh
+}

--- a/internal/bulk.go
+++ b/internal/bulk.go
@@ -97,6 +97,14 @@ func processRequest(ctx context.Context, req BulkRequest, seq int64, err error) 
 			return res
 		}
 		res.Payload, _ = json.Marshal(env)
+	case "keygen":
+		key := dsig.NewES256Key()
+
+		res.Payload, _ = json.Marshal(KeygenResponse{
+			Private: key,
+			Public:  key.Public(),
+		})
+
 	default:
 		res.Error = fmt.Sprintf("Unrecognized action '%s'", req.Action)
 	}
@@ -120,4 +128,10 @@ type BuildRequest struct {
 	Data       json.RawMessage  `json:"data"`
 	PrivateKey *dsig.PrivateKey `json:"privatekey"`
 	DocType    string           `json:"type"`
+}
+
+// KeygenResponse is the payload for a key generation response.
+type KeygenResponse struct {
+	Private *dsig.PrivateKey `json:"private"`
+	Public  *dsig.PublicKey  `json:"public"`
 }

--- a/internal/bulk.go
+++ b/internal/bulk.go
@@ -81,6 +81,21 @@ func processRequest(ctx context.Context, req BulkRequest, seq int64, err error) 
 			return res
 		}
 		res.Payload, _ = json.Marshal(VerifyResponse{OK: true})
+	case "build":
+		bld := &BuildRequest{}
+		if err := json.Unmarshal(req.Payload, bld); err != nil {
+			res.Error = err.Error()
+			return res
+		}
+		env, err := Build(ctx, &BuildOptions{
+			Data:       bytes.NewReader(bld.Data),
+			PrivateKey: bld.PrivateKey,
+		})
+		if err != nil {
+			res.Error = err.Error()
+			return res
+		}
+		res.Payload, _ = json.Marshal(env)
 	}
 	return res
 }
@@ -94,4 +109,12 @@ type VerifyRequest struct {
 // VerifyResponse is the response to a verification request.
 type VerifyResponse struct {
 	OK bool `json:"ok"`
+}
+
+// BuildRequest is the payload for a build reqeuest.
+type BuildRequest struct {
+	Template   json.RawMessage  `json:"template"`
+	Data       json.RawMessage  `json:"data"`
+	PrivateKey *dsig.PrivateKey `json:"privatekey"`
+	DocType    string           `json:"type"`
 }

--- a/internal/bulk_test.go
+++ b/internal/bulk_test.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gitlab.com/flimzy/testy"
+)
+
+func TestBulk(t *testing.T) {
+	type tt struct {
+		in   io.Reader
+		want []*BulkResponse
+	}
+
+	tests := testy.NewTable()
+	tests.Add("invalid input", tt{
+		in: strings.NewReader("this ain't json"),
+		want: []*BulkResponse{
+			{
+				SeqID:   0,
+				Error:   "invalid character 'h' in literal true (expecting 'r')",
+				IsFinal: true,
+			},
+		},
+	})
+	tests.Add("one verification", func(t *testing.T) interface{} {
+		payload, err := ioutil.ReadFile("testdata/success.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err := json.Marshal(BulkRequest{
+			Action:  "verify",
+			ReqID:   "asdf",
+			Payload: payload,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tt{
+			in: bytes.NewReader(req),
+			want: []*BulkResponse{
+				{
+					ReqID:   "asdf",
+					SeqID:   0,
+					IsFinal: false,
+				},
+				{
+					SeqID:   1,
+					IsFinal: true,
+				},
+			},
+		}
+	})
+
+	tests.Run(t, func(t *testing.T, tt tt) {
+		ch := Bulk(tt.in)
+		results := []*BulkResponse{}
+		for res := range ch {
+			results = append(results, res)
+		}
+		if d := cmp.Diff(results, tt.want, cmpopts.IgnoreFields(BulkResponse{}, "Payload")); d != "" {
+			t.Error(d)
+		}
+	})
+}

--- a/internal/bulk_test.go
+++ b/internal/bulk_test.go
@@ -308,6 +308,30 @@ func TestBulk(t *testing.T) {
 			},
 		}
 	})
+	tests.Add("unknown action", func(t *testing.T) interface{} {
+		req, err := json.Marshal(map[string]interface{}{
+			"action": "frobnicate",
+			"req_id": "asdf",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tt{
+			in: io.MultiReader(bytes.NewReader(req)),
+			want: []*BulkResponse{
+				{
+					ReqID:   "asdf",
+					SeqID:   1,
+					Error:   "Unrecognized action 'frobnicate'",
+					IsFinal: false,
+				},
+				{
+					SeqID:   2,
+					IsFinal: true,
+				},
+			},
+		}
+	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {
 		ch := Bulk(context.Background(), tt.in)

--- a/internal/bulk_test.go
+++ b/internal/bulk_test.go
@@ -332,6 +332,29 @@ func TestBulk(t *testing.T) {
 			},
 		}
 	})
+	tests.Add("keygen", func(t *testing.T) interface{} {
+		req, err := json.Marshal(map[string]interface{}{
+			"action": "keygen",
+			"req_id": "asdf",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tt{
+			in: io.MultiReader(bytes.NewReader(req)),
+			want: []*BulkResponse{
+				{
+					ReqID:   "asdf",
+					SeqID:   1,
+					IsFinal: false,
+				},
+				{
+					SeqID:   2,
+					IsFinal: true,
+				},
+			},
+		}
+	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {
 		ch := Bulk(context.Background(), tt.in)

--- a/internal/bulk_test.go
+++ b/internal/bulk_test.go
@@ -31,6 +31,15 @@ func TestBulk(t *testing.T) {
 			},
 		},
 	})
+	tests.Add("no input", tt{
+		in: strings.NewReader(""),
+		want: []*BulkResponse{
+			{
+				SeqID:   1,
+				IsFinal: true,
+			},
+		},
+	})
 	tests.Add("one verification", func(t *testing.T) interface{} {
 		payload, err := ioutil.ReadFile("testdata/success.json")
 		if err != nil {


### PR DESCRIPTION
This adds the `internal.Bulk` command, which will be the core of the bulk operation handling for the CLI, REST API, and future WASM API.

The CLI work is in progress, but requires a bit of refactoring that will make this PR too noisy, so I'll merge that next.