### PR TITLE
Fix nil pointer dereference for keygen Cobra command

### DIFF
--- a/cmd/gobl/keygen.go
+++ b/cmd/gobl/keygen.go
@@ -19,7 +19,9 @@ type keygenOpts struct {
 }
 
 func keygen(root *rootOpts) *keygenOpts {
-	return &keygenOpts{}
+	return &keygenOpts{
+		rootOpts: root,
+	}
 }
 
 func (k *keygenOpts) cmd() *cobra.Command {


### PR DESCRIPTION
When constructing a `keygenOpts` value, the embedded `*rootOpts` field wasn't populated. This led to a `runtime error: invalid memory address or nil pointer dereference` panic  when invoking `gobl keygen`. To fix this, this PR updates the `keygen` function to use the `*rootOpts` function argument when constructing the `keygenOpts` value.