### PR TITLE
Add default signing key parameter to `serve`

### DIFF
--- a/cmd/gobl/bulk.go
+++ b/cmd/gobl/bulk.go
@@ -31,7 +31,10 @@ func (o *bulkOpts) runE(cmd *cobra.Command, args []string) error {
 	if o.indent {
 		enc.SetIndent("", "\t")
 	}
-	for result := range internal.Bulk(ctx, in) {
+	opts := &internal.BulkOptions{
+		In: in,
+	}
+	for result := range internal.Bulk(ctx, opts) {
 		if err := enc.Encode(result); err != nil {
 			return err
 		}

--- a/cmd/gobl/keygen.go
+++ b/cmd/gobl/keygen.go
@@ -13,6 +13,8 @@ import (
 	"github.com/invopop/gobl/dsig"
 )
 
+const defaultKeyFilename = "~/.gobl/id_es256.jwk"
+
 type keygenOpts struct {
 	*rootOpts
 	overwrite bool
@@ -61,13 +63,8 @@ func homedir() (string, error) {
 	return user.HomeDir, nil
 }
 
-func defaultKeyfile() (string, error) {
-	const defaultFilename = ".gobl/id_es256.jwk"
-	home, err := homedir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, defaultFilename), nil
+func defaultKeyfile() (string,error) {
+	return expandHome(defaultKeyFilename)
 }
 
 func outputKeyfile(args []string) (string, error) {

--- a/cmd/gobl/sign.go
+++ b/cmd/gobl/sign.go
@@ -77,18 +77,8 @@ func (opts *signOpts) runE(cmd *cobra.Command, args []string) error {
 	}
 	defer out.Close() // nolint:errcheck
 
-	pkFilename, err := expandHome(opts.privateKeyFile)
+	key, err := loadPrivateKey(opts.privateKeyFile)
 	if err != nil {
-		return err
-	}
-	keyFile, err := os.Open(pkFilename)
-	if err != nil {
-		return err
-	}
-	defer keyFile.Close() // nolint:errcheck
-
-	key := new(dsig.PrivateKey)
-	if err = json.NewDecoder(keyFile).Decode(key); err != nil {
 		return err
 	}
 
@@ -115,4 +105,23 @@ func (opts *signOpts) runE(cmd *cobra.Command, args []string) error {
 	}
 
 	return enc.Encode(env)
+}
+
+func loadPrivateKey(file string) (*dsig.PrivateKey, error) {
+	pkFilename, err := expandHome(file)
+	if err != nil {
+		return nil, err
+	}
+	keyFile, err := os.Open(pkFilename)
+	if err != nil {
+		return nil, err
+	}
+	defer keyFile.Close() // nolint:errcheck
+
+	key := new(dsig.PrivateKey)
+	if err = json.NewDecoder(keyFile).Decode(key); err != nil {
+		return nil, err
+	}
+
+	return key, nil
 }

--- a/cmd/gobl/sign.go
+++ b/cmd/gobl/sign.go
@@ -46,7 +46,7 @@ func (opts *signOpts) cmd() *cobra.Command {
 	f.StringToStringVar(&opts.setFiles, "set-file", nil, "Set value from the specified YAML or JSON file")
 	f.StringToStringVar(&opts.setStrings, "set-string", nil, "Set STRING value from the command line")
 	f.StringVarP(&opts.template, "template", "T", "", "Template YAML/JSON file into which data is merged")
-	f.StringVarP(&opts.privateKeyFile, "key", "k", "~/.gobl/id_es256.jwk", "Private key file for signing")
+	f.StringVarP(&opts.privateKeyFile, "key", "k", defaultKeyFilename, "Private key file for signing")
 	f.StringVarP(&opts.docType, "type", "t", "", "Specify the document type")
 
 	return cmd

--- a/cmd/gobl/verify.go
+++ b/cmd/gobl/verify.go
@@ -27,7 +27,7 @@ func (v *verifyOpts) cmd() *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringVarP(&v.publicKeyFile, "key", "k", "~/.gobl/id_es256.pub.jwk", "Public key file for signature validation")
+	f.StringVarP(&v.publicKeyFile, "key", "k", pubfileFromPriv(defaultKeyFilename), "Public key file for signature validation")
 
 	return cmd
 }

--- a/internal/bulk_test.go
+++ b/internal/bulk_test.go
@@ -17,13 +17,15 @@ import (
 
 func TestBulk(t *testing.T) {
 	type tt struct {
-		in   io.Reader
+		opts *BulkOptions
 		want []*BulkResponse
 	}
 
 	tests := testy.NewTable()
 	tests.Add("invalid input", tt{
-		in: strings.NewReader("this ain't json"),
+		opts: &BulkOptions{
+			In: strings.NewReader("this ain't json"),
+		},
 		want: []*BulkResponse{
 			{
 				SeqID:   1,
@@ -33,7 +35,9 @@ func TestBulk(t *testing.T) {
 		},
 	})
 	tests.Add("no input", tt{
-		in: strings.NewReader(""),
+		opts: &BulkOptions{
+			In: strings.NewReader(""),
+		},
 		want: []*BulkResponse{
 			{
 				SeqID:   1,
@@ -58,7 +62,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: bytes.NewReader(req),
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -85,7 +91,9 @@ func TestBulk(t *testing.T) {
 			"payload": "50ms",
 		})
 		return tt{
-			in: io.MultiReader(bytes.NewReader(req1), bytes.NewReader(req2)),
+			opts: &BulkOptions{
+				In: io.MultiReader(bytes.NewReader(req1), bytes.NewReader(req2)),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "abc",
@@ -123,7 +131,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: io.MultiReader(bytes.NewReader(req), strings.NewReader("not json")),
+			opts: &BulkOptions{
+				In: io.MultiReader(bytes.NewReader(req), strings.NewReader("not json")),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -149,7 +159,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: io.MultiReader(bytes.NewReader(req)),
+			opts: &BulkOptions{
+				In: io.MultiReader(bytes.NewReader(req)),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -177,7 +189,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: io.MultiReader(bytes.NewReader(req)),
+			opts: &BulkOptions{
+				In: io.MultiReader(bytes.NewReader(req)),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -209,7 +223,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: bytes.NewReader(req),
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -241,7 +257,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: bytes.NewReader(req),
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID: "asdf",
@@ -273,7 +291,9 @@ func TestBulk(t *testing.T) {
 			},
 		})
 		return tt{
-			in: bytes.NewReader(req),
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+			},
 			want: []*BulkResponse{
 				{
 					SeqID: 1,
@@ -299,7 +319,9 @@ func TestBulk(t *testing.T) {
 			},
 		})
 		return tt{
-			in: bytes.NewReader(req),
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+			},
 			want: []*BulkResponse{
 				{
 					SeqID: 1,
@@ -322,7 +344,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: io.MultiReader(bytes.NewReader(req)),
+			opts: &BulkOptions{
+				In: io.MultiReader(bytes.NewReader(req)),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -350,7 +374,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: io.MultiReader(bytes.NewReader(req)),
+			opts: &BulkOptions{
+				In: io.MultiReader(bytes.NewReader(req)),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -374,7 +400,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: io.MultiReader(bytes.NewReader(req)),
+			opts: &BulkOptions{
+				In: io.MultiReader(bytes.NewReader(req)),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -398,7 +426,9 @@ func TestBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 		return tt{
-			in: bytes.NewReader(req),
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+			},
 			want: []*BulkResponse{
 				{
 					ReqID:   "asdf",
@@ -413,30 +443,102 @@ func TestBulk(t *testing.T) {
 		}
 	})
 	tests.Add("ping", tt{
-		in: strings.NewReader(`{"action":"ping"}`),
+		opts: &BulkOptions{
+			In: strings.NewReader(`{"action":"ping"}`),
+		},
 		want: []*BulkResponse{
 			{SeqID: 1},
 			{SeqID: 2, IsFinal: true},
 		},
 	})
 	tests.Add("sleep", tt{
-		in: strings.NewReader(`{"action":"sleep","payload":"10ms"}`),
+		opts: &BulkOptions{
+			In: strings.NewReader(`{"action":"sleep","payload":"10ms"}`),
+		},
 		want: []*BulkResponse{
 			{SeqID: 1},
 			{SeqID: 2, IsFinal: true},
 		},
 	})
 	tests.Add("out of order", tt{
-		in: strings.NewReader(`{"action":"sleep","payload":"100ms","req_id":"sleep"} {"action":"ping","req_id":"ping"}`),
+		opts: &BulkOptions{
+			In: strings.NewReader(`{"action":"sleep","payload":"100ms","req_id":"sleep"} {"action":"ping","req_id":"ping"}`),
+		},
 		want: []*BulkResponse{
 			{SeqID: 2, ReqID: "ping"},
 			{SeqID: 1, ReqID: "sleep"},
 			{SeqID: 3, IsFinal: true},
 		},
 	})
+	tests.Add("sign, explicit key given", func(t *testing.T) interface{} {
+		payload, err := os.ReadFile("testdata/nosig.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err := json.Marshal(map[string]interface{}{
+			"action": "sign",
+			"req_id": "asdf",
+			"payload": map[string]interface{}{
+				"data":       base64.StdEncoding.EncodeToString(payload),
+				"privatekey": privateKey,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tt{
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+			},
+			want: []*BulkResponse{
+				{
+					ReqID: "asdf",
+					SeqID: 1,
+					IsFinal: false,
+				},
+				{
+					SeqID:   2,
+					IsFinal: true,
+				},
+			},
+		}
+	})
+	tests.Add("sign, default key", func(t *testing.T) interface{} {
+		payload, err := os.ReadFile("testdata/nosig.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err := json.Marshal(map[string]interface{}{
+			"action": "sign",
+			"req_id": "asdf",
+			"payload": map[string]interface{}{
+				"data": base64.StdEncoding.EncodeToString(payload),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tt{
+			opts: &BulkOptions{
+				In: bytes.NewReader(req),
+				DefaultPrivateKey: privateKey,
+			},
+			want: []*BulkResponse{
+				{
+					ReqID: "asdf",
+					SeqID: 1,
+					IsFinal: false,
+				},
+				{
+					SeqID:   2,
+					IsFinal: true,
+				},
+			},
+		}
+	})
 
 	tests.Run(t, func(t *testing.T, tt tt) {
-		ch := Bulk(context.Background(), tt.in)
+		ch := Bulk(context.Background(), tt.opts)
 		results := []*BulkResponse{}
 		for res := range ch {
 			results = append(results, res)

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -24,7 +24,10 @@ func main() {
 
 	js.Global().Call("postMessage", map[string]interface{}{"ready": true})
 
-	for result := range internal.Bulk(context.TODO(), r) {
+	bulkOpts := &internal.BulkOptions{
+		In: r,
+	}
+	for result := range internal.Bulk(context.TODO(), bulkOpts) {
 		response := js.Global().Get("Object").New()
 		if result.ReqID != "" {
 			response.Set("req_id", result.ReqID)


### PR DESCRIPTION
⚠️ _This is my first attempt to change a Go project ever. I really don't know much about the language or its conventions. I'm leaving my own comments in the PR with doubts and questions. So, please, review thoroughly and be merciless when suggesting changes._ ⚠️ 

* This PRs adds the ability to define a default signing key to be used when "sign" requests are received by the service that the `serve` command exposes.
* I took as a reference the implementation of the same functionality in the `sign` command.
* Please see my own comments in the PR below.

